### PR TITLE
teat: add test for Q14/Q27

### DIFF
--- a/questions/14-dynamic-css-values/index.test.ts
+++ b/questions/14-dynamic-css-values/index.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from "vitest"
+
+import AppRaw from "./App.vue?raw"
+
+describe("DomPortal", () => {
+  it("render to body", () => {
+    expect(AppRaw).toContain("color: v-bind(theme)")
+  })
+})

--- a/questions/27-global-css/index.test.ts
+++ b/questions/27-global-css/index.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from "vitest"
+
+import AppRaw from "./App.vue?raw"
+
+describe("DomPortal", () => {
+  it("render to body", () => {
+    expect(AppRaw).toContain(":global(body)")
+  })
+})


### PR DESCRIPTION
Because the test package cannot get the CSS, this util test use vite to directly match keywords in the code.
it's ugly but useful.
and, currently all tests have been completed. Thank for this project and you!!!
🎉🎉🎉🎉