### PR TITLE
fix test case in question-232

### DIFF
--- a/questions/232-key-modifiers/index.test.ts
+++ b/questions/232-key-modifiers/index.test.ts
@@ -15,9 +15,14 @@ describe("key modifiers", () => {
 
     await buttons[0].trigger('click')
     expect(printLog).toMatchInlineSnapshot('""')
+    printLog = ""
     await buttons[0].trigger('click.alt')
     expect(printLog).toMatchInlineSnapshot('"onClick1"')
+    printLog = ""
     await buttons[0].trigger('click.shift')
+    expect(printLog).toMatchInlineSnapshot('"onClick1"')
+    printLog = ""
+    await buttons[0].trigger('click.shift.alt')
     expect(printLog).toMatchInlineSnapshot('"onClick1"')
 
     await buttons[1].trigger('click')


### PR DESCRIPTION
In question 232，we need change add key modifiers made this will fire even if Alt or Shift is also pressed. But in the test case of question 232, if we passed the case
```
await buttons[0].trigger('click.alt')
expect(printLog).toMatchInlineSnapshot('"onClick1"')
```
`printLog` can't be empty, so that the case will always be passed until the next time to call `console.log`.
So even if the answer only writes `alt` key modifer like this:
```
<button @click.alt="onClick1">A</button>
```
it's still passed.

Futhermore, there isn't a case includes Alt and Shift are pressed at the same time, I added.